### PR TITLE
Ensure product updates refresh timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ name = "pushkind-crawlers"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "diesel",
  "dotenvy",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1.83"
 zmq = "0.10.0"
 pushkind-common = { git = "https://github.com/pushkindt/pushkind-common.git", branch = "main", features = ["dantes"] }
 diesel = { version = "2.2.12", features = ["sqlite", "r2d2", "chrono", "returning_clauses_for_sqlite_3_35"] }
+chrono = { version = "0.4.41", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/src/repository/product.rs
+++ b/src/repository/product.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use diesel::prelude::*;
 use pushkind_common::db::DbPool;
 use pushkind_common::domain::product::NewProduct;
@@ -43,7 +44,7 @@ impl ProductWriter for DieselProductRepository<'_> {
                 .values(&db_product)
                 .on_conflict((products::crawler_id, products::url))
                 .do_update()
-                .set(&db_product)
+                .set((&db_product, products::updated_at.eq(Utc::now().naive_utc())))
                 .execute(&mut conn)?;
             affected_rows += rows;
         }


### PR DESCRIPTION
## Summary
- use `chrono::Utc` to update product `updated_at` field
- add `chrono` as direct dependency

## Testing
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_688f9a27351c832fb16ff3e1d82a652b