### PR TITLE
docs: document benchmark embedding workflow

### DIFF
--- a/src/processing/benchmark.rs
+++ b/src/processing/benchmark.rs
@@ -7,6 +7,10 @@ use crate::repository::benchmark::DieselBenchmarkRepository;
 use crate::repository::product::DieselProductRepository;
 use crate::repository::{BenchmarkReader, BenchmarkWriter, ProductReader, ProductWriter};
 
+/// Build a textual prompt describing a benchmark or product for embedding.
+///
+/// The prompt includes the following fields in order: name, SKU, category,
+/// units, price, amount and description.
 fn prompt(
     name: &str,
     sku: &str,
@@ -21,6 +25,14 @@ fn prompt(
     )
 }
 
+/// Generate embeddings for a benchmark and related products, build a search
+/// index and update benchmark-product associations.
+///
+/// The function fetches the benchmark and all products for the same hub,
+/// generates missing embeddings using the multilingual E5 model, persists
+/// them, then builds a cosine index with `usearch` to find the closest
+/// products. Associations in the database are replaced with the top results
+/// and the benchmark processing flag is updated when complete.
 pub async fn process_benchmark_message(benchmark_id: i32, db_pool: &DbPool) {
     log::info!("Received benchmark: {benchmark_id:?}");
 


### PR DESCRIPTION
## Summary
- document fields covered by benchmark/product prompt
- document benchmark embedding workflow and index update

## Testing
- `cargo doc --no-deps` *(fails: Failed to GET `https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz`: CONNECT proxy failed: proxy server responded 403/403)*

------
https://chatgpt.com/codex/tasks/task_e_6890b791e1c4832f885e0974fca56ce7