### PR TITLE
doc: add comments for processing enums

### DIFF
--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -6,7 +6,7 @@ pub mod crawler;
 /// Messages received over ZMQ to control crawlers or run benchmarks.
 ///
 /// - `Crawler` requests execution of a crawler described by [`CrawlerSelector`].
-/// - `Benchmark` triggers a benchmark run with the provided iteration count.
+/// - `Benchmark` triggers a benchmark run with the provided benchmark_id.
 #[derive(Deserialize, Debug)]
 pub enum ZMQMessage {
     /// Run the specified crawler.
@@ -15,7 +15,7 @@ pub enum ZMQMessage {
     Benchmark(i32),
 }
 
-/// Selects a crawler and optionally a list of product IDs to crawl.
+/// Selects a crawler and optionally a list of product URLs to crawl.
 ///
 /// - `Selector` chooses a crawler by name.
 /// - `SelectorProducts` specifies a crawler and products to fetch.
@@ -23,6 +23,6 @@ pub enum ZMQMessage {
 pub enum CrawlerSelector {
     /// Run the named crawler.
     Selector(String),
-    /// Run the named crawler with the provided product IDs.
+    /// Run the named crawler with the provided product URLs.
     SelectorProducts((String, Vec<String>)),
 }


### PR DESCRIPTION
## Summary
- document ZMQMessage and CrawlerSelector enums

## Testing
- `cargo doc --no-deps` *(fails: Failed to GET https://cdn.pyke.io/... 403)*
- `ORT_SKIP_DOWNLOAD=1 cargo doc --no-deps` *(fails: empty search path given via `-L`)*
- `ORT_SKIP_DOWNLOAD=1 cargo test` *(fails: empty search path given via `-L`)*

------
https://chatgpt.com/codex/tasks/task_e_6890b78f66d4832f9e3f51d6f7218cc0