### PR TITLE
docs: explain product refresh in crawler

### DIFF
--- a/src/processing/crawler.rs
+++ b/src/processing/crawler.rs
@@ -10,6 +10,10 @@ use crate::repository::ProductWriter;
 use crate::repository::crawler::DieselCrawlerRepository;
 use crate::repository::product::DieselProductRepository;
 
+/// Processes a message for a specific crawler and either refreshes all of its
+/// products or updates a subset. When no product URLs are provided, existing
+/// items are cleared and the crawler fetches all products anew. If URLs are
+/// supplied, only those products are retrieved and updated in the repository.
 pub async fn process_crawler_message(msg: CrawlerSelector, db_pool: &DbPool) {
     log::info!("Received crawler: {msg:?}");
     let product_repo = DieselProductRepository::new(db_pool);


### PR DESCRIPTION
## Summary
- document how `process_crawler_message` refreshes or updates products

## Testing
- `cargo doc --no-deps` *(fails: failed to GET https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz: CONNECT proxy failed: proxy server responded 403/403)*

------
https://chatgpt.com/codex/tasks/task_e_6890b7aa29bc832faadba402df17a96c