### PR TITLE
Document Rusteaco crawler

### DIFF
--- a/src/crawlers/mod.rs
+++ b/src/crawlers/mod.rs
@@ -4,8 +4,15 @@ use pushkind_common::domain::product::NewProduct;
 pub mod rusteaco;
 pub mod tea101;
 
+/// An abstraction over web store crawlers that produce [`NewProduct`]s.
 #[async_trait]
 pub trait Crawler {
+    /// Crawls the target site and returns every product discovered.
     async fn get_products(&self) -> Vec<NewProduct>;
+
+    /// Fetches product information from a single URL.
+    ///
+    /// Some pages may describe multiple product variants, therefore the
+    /// implementation returns a collection of [`NewProduct`]s.
     async fn get_product(&self, url: &str) -> Vec<NewProduct>;
 }

--- a/src/crawlers/rusteaco.rs
+++ b/src/crawlers/rusteaco.rs
@@ -23,6 +23,7 @@ struct ProductJson {
     variants: Vec<Variant>,
 }
 
+/// Converts a [`Variant`] produced by the store into a [`NewProduct`].
 fn variant_to_product(
     v: Variant,
     name: &str,
@@ -52,6 +53,8 @@ fn variant_to_product(
     }
 }
 
+/// Crawler for `shop.rusteaco.ru` which limits concurrent HTTP requests
+/// using a [`Semaphore`].
 pub struct WebstoreCrawlerRusteaco {
     crawler_id: i32,
     base_url: Url,
@@ -60,6 +63,10 @@ pub struct WebstoreCrawlerRusteaco {
 }
 
 impl WebstoreCrawlerRusteaco {
+    /// Creates a new crawler with the given concurrency limit.
+    ///
+    /// `concurrency` controls how many HTTP requests may be in flight at the
+    /// same time. The `crawler_id` is attached to each produced product.
     pub fn new(concurrency: usize, crawler_id: i32) -> Self {
         Self {
             crawler_id,
@@ -69,6 +76,10 @@ impl WebstoreCrawlerRusteaco {
         }
     }
 
+    /// Fetches a URL and parses it into [`Html`].
+    ///
+    /// A permit from the internal [`Semaphore`] is acquired before issuing
+    /// the request, enforcing the configured concurrency limit.
     async fn fetch_html(&self, url: &str) -> Option<Html> {
         let _permit = self.semaphore.acquire().await.ok()?;
         let res = self.client.get(url).send().await.ok()?;
@@ -80,6 +91,7 @@ impl WebstoreCrawlerRusteaco {
         Some(Html::parse_document(&text))
     }
 
+    /// Retrieves all category links from the store's landing page.
     async fn get_category_links(&self) -> Vec<String> {
         let document = match self.fetch_html(self.base_url.as_str()).await {
             Some(doc) => doc,
@@ -100,6 +112,8 @@ impl WebstoreCrawlerRusteaco {
             .collect()
     }
 
+    /// For a given category URL, discovers all pagination links, returning
+    /// the original URL and any additional pages.
     async fn get_page_links(&self, url: &str) -> Vec<String> {
         let mut result = vec![url.to_string()];
         let document = match self.fetch_html(url).await {
@@ -155,6 +169,7 @@ impl WebstoreCrawlerRusteaco {
         result
     }
 
+    /// Extracts product detail links from a listing page.
     async fn get_product_links(&self, url: &str) -> Vec<String> {
         let document = match self.fetch_html(url).await {
             Some(doc) => doc,
@@ -177,6 +192,12 @@ impl WebstoreCrawlerRusteaco {
 
 #[async_trait]
 impl Crawler for WebstoreCrawlerRusteaco {
+    /// Crawls the entire web store and returns all discovered products.
+    ///
+    /// Category pages, pagination, product links and product details are
+    /// fetched concurrently with `join_all`, while [`fetch_html`] ensures the
+    /// number of simultaneous HTTP requests never exceeds the configured
+    /// limit.
     async fn get_products(&self) -> Vec<NewProduct> {
         let categories = self.get_category_links().await;
 
@@ -208,6 +229,10 @@ impl Crawler for WebstoreCrawlerRusteaco {
         products
     }
 
+    /// Fetches product information from a single product page.
+    ///
+    /// A page may describe multiple variants; each variant is converted into
+    /// its own [`NewProduct`].
     async fn get_product(&self, url: &str) -> Vec<NewProduct> {
         let document = match self.fetch_html(url).await {
             Some(doc) => doc,


### PR DESCRIPTION
## Summary
- document Crawler trait methods
- expand WebstoreCrawlerRusteaco docs, including concurrency-aware helpers

## Testing
- `cargo test` *(fails: Failed to GET https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz: CONNECT proxy failed: proxy server responded 403/403)*
- `cargo doc --no-deps` *(fails: Failed to GET https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz: CONNECT proxy failed: proxy server responded 403/403)*


------
https://chatgpt.com/codex/tasks/task_e_6890b7afbd50832fb13761349f08251c