### PR TITLE
Add prompt test for benchmark processing

### DIFF
--- a/src/processing/benchmark.rs
+++ b/src/processing/benchmark.rs
@@ -193,3 +193,24 @@ pub async fn process_benchmark_message(benchmark_id: i32, db_pool: &DbPool) {
 
     log::info!("Finished processing benchmark: {benchmark_id}");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_produces_expected_string() {
+        let result = prompt(
+            "Sample Name",
+            "SKU123",
+            "Category",
+            "units",
+            9.99,
+            2.0,
+            "Description",
+        );
+
+        let expected = "Name: Sample Name\nSKU: SKU123\nCategory: Category\nUnits: units\nPrice: 9.99\nAmount: 2\nDescription: Description";
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test verifying benchmark prompt format

## Testing
- `cargo test --processing benchmark` *(fails: unexpected argument '--processing')*
- `cargo test` *(fails: Failed to GET `https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz`: CONNECT proxy failed: proxy server responded 403/403)*

------
https://chatgpt.com/codex/tasks/task_e_6890bafa6514832fa470be37d6d45041